### PR TITLE
Warn about default user agent once per session

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,33 @@ but this file may sometimes contain later improvements (e.g. typo fixes).
   The `fetch.js` and `axios.js` backends already add a default for this option,
   so this is only relevant for you if you wrote a custom network implementation;
   if you just import `browser.js` or `node.js`, it doesn’t matter.
+- Requests that do not specify a user agent will now trigger a warning,
+  limited to once per session.
+  If you see this warning, you should add a user agent to your requests –
+  see the [User-Agent policy][].
+  Usually you would add it to the default options at construction time:
+  ```js
+  const session = new Session( 'https://en.wikipedia.org/w/api.php', {
+      formatversion: 2,
+	  // other default params...
+  }, {
+	  userAgent: 'my-cool-tool',
+	  // other default options...
+  } );
+  ```
+  But it can also be specified for an individual request:
+  ```js
+  const response = await session.request( {
+      action: 'query',
+	  // other params...
+  }, {
+	  userAgent: 'my-cool-tool',
+	  // other default options...
+  } );
+  ```
+  Recall that the default warning handler is `console.warn` in the browser,
+  and also in Node.js if NODE_ENV = “development” is set,
+  but otherwise the Node.js backend ignores warnings.
 
 ## v0.4.0 (2021-11-13)
 
@@ -101,3 +128,4 @@ The Git commit for this version was probably 00e278a13b50cc903b6fb3d530033098d3a
 but I see no reason to recreate the tag now.
 
 [CVE-2021-3749]: https://github.com/advisories/GHSA-cph5-m8f7-6c5x
+[User-Agent policy]: https://meta.wikimedia.org/wiki/Special:MyLanguage/User-Agent_policy

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,12 @@ but this file may sometimes contain later improvements (e.g. typo fixes).
 
 ## next (not yet released)
 
-No changes yet.
+- BREAKING CHANGE (internal):
+  The `Session` constructor now requires the default request options to include `warn`,
+  which must be a function.
+  The `fetch.js` and `axios.js` backends already add a default for this option,
+  so this is only relevant for you if you wrote a custom network implementation;
+  if you just import `browser.js` or `node.js`, it doesn’t matter.
 
 ## v0.4.0 (2021-11-13)
 

--- a/core.js
+++ b/core.js
@@ -80,6 +80,14 @@ class Session {
 	constructor( apiUrl, defaultParams = {}, defaultOptions = {} ) {
 		this.defaultParams = defaultParams;
 		this.defaultOptions = defaultOptions;
+
+		if ( typeof defaultOptions.warn !== 'function' ) {
+			let message = '`warn` request option must be a function';
+			if ( !( 'warn' in defaultOptions ) ) {
+				message += ' (Session subclasses must provide a default for this option)';
+			}
+			throw new Error( message );
+		}
 	}
 
 	/**

--- a/test/unit/combine.test.js
+++ b/test/unit/combine.test.js
@@ -2,6 +2,7 @@
 
 import { mixCombiningSessionInto } from '../../combine.js';
 import { Session, set } from '../../core.js';
+import { BaseTestSession } from './core.test.js';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 chai.use( chaiAsPromised );
@@ -29,7 +30,7 @@ describe( 'CombiningSession', () => {
 	function singleGetSession( expectedParams, response_ = response ) {
 		expectedParams.format = 'json';
 		let called = false;
-		class TestSession extends Session {
+		class TestSession extends BaseTestSession {
 			async internalGet( params ) {
 				expect( called, 'internalGet already called' ).to.be.false;
 				called = true;
@@ -262,7 +263,7 @@ describe( 'CombiningSession', () => {
 
 	it( 'propagates errors', async () => {
 		const error = new Error();
-		class TestSession extends Session {
+		class TestSession extends BaseTestSession {
 			async internalGet() {
 				throw error;
 			}
@@ -333,7 +334,7 @@ describe( 'CombiningSession', () => {
 	 */
 	function sequentialGetSession( expectedCalls ) {
 		expectedCalls.reverse();
-		class TestSession extends Session {
+		class TestSession extends BaseTestSession {
 			async internalGet( params ) {
 				expect( expectedCalls ).to.not.be.empty;
 				const [ { expectedParams, response } ] = expectedCalls.splice( -1 );


### PR DESCRIPTION
If a request doesn’t specify a custom user agent, send a warning to its warning handler. (This is allowed, since the documentation says the handler can be called with `Error` instances, including but not limited to `ApiWarnings`.) To reduce logspam, only do this once per session. The relevant field is only added to the session instance after we’ve sent the warning, so well-behaved users should never have to pay the few extra bytes for their session instances, since they’ll never hit that code path.

Fixes #4.