### PR TITLE
Allow first constructor argument to be domain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ but this file may sometimes contain later improvements (e.g. typo fixes).
   The `fetch.js` and `axios.js` backends already add a default for this option,
   so this is only relevant for you if you wrote a custom network implementation;
   if you just import `browser.js` or `node.js`, it doesn’t matter.
+- The first constructor argument can now be a domain name instead of a full `api.php` URL,
+  e.g. `en.wikipedia.org` instead of `https://en.wikipedia.org/w/api.php`.
 - Requests that do not specify a user agent will now trigger a warning,
   limited to once per session.
   If you see this warning, you should add a user agent to your requests –

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ but this file may sometimes contain later improvements (e.g. typo fixes).
   see the [User-Agent policy][].
   Usually you would add it to the default options at construction time:
   ```js
-  const session = new Session( 'https://en.wikipedia.org/w/api.php', {
+  const session = new Session( en.wikipedia.org, {
       formatversion: 2,
 	  // other default params...
   }, {

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ import Session, { set } from './node.js';
 // note: this example uses top-level await for simplicity,
 // you may need an async wrapper function
 
-// create a session from an api.php URL
-const session = new Session( 'https://en.wikipedia.org/w/api.php', {
+// create a session from a wiki domain (or full api.php URL)
+const session = new Session( 'en.wikipedia.org', {
 	// these default parameters will be added to all requests
 	formatversion: 2,
 	errorformat: 'plaintext',

--- a/axios.js
+++ b/axios.js
@@ -27,7 +27,7 @@ class AxiosSession extends Session {
 		}
 		super( apiUrl, defaultParams, defaultOptions );
 		this.session = axios.create( {
-			baseURL: apiUrl,
+			baseURL: this.apiUrl,
 		} );
 		axiosCookieJarSupport( this.session );
 		Object.assign( this.session.defaults, { // must happen after axiosCookieJarSupport

--- a/core.js
+++ b/core.js
@@ -87,7 +87,8 @@ class Session {
 
 	/**
 	 * @param {string} apiUrl The URL to the api.php endpoint,
-	 * such as https://en.wikipedia.org/w/api.php
+	 * such as {@link https://en.wikipedia.org/w/api.php}.
+	 * Can also be just the domain, such as en.wikipedia.org.
 	 * @param {Object} [defaultParams] Parameters to include in every API request.
 	 * See {@link #request} for supported value types.
 	 * You are strongly encouraged to specify formatversion: 2 here;
@@ -98,8 +99,13 @@ class Session {
 	 * {@link https://meta.wikimedia.org/wiki/User-Agent_policy User-Agent policy}.
 	 */
 	constructor( apiUrl, defaultParams = {}, defaultOptions = {} ) {
+		this.apiUrl = apiUrl;
 		this.defaultParams = defaultParams;
 		this.defaultOptions = defaultOptions;
+
+		if ( !this.apiUrl.includes( '/' ) ) {
+			this.apiUrl = `https://${this.apiUrl}/w/api.php`;
+		}
 
 		if ( typeof defaultOptions.warn !== 'function' ) {
 			let message = '`warn` request option must be a function';

--- a/fetch.js
+++ b/fetch.js
@@ -22,7 +22,7 @@ class FetchSession extends Session {
 			defaultOptions.warn = console.warn;
 		}
 		super( apiUrl, defaultParams, defaultOptions );
-		this.baseUrl = apiUrl;
+		this.baseUrl = this.apiUrl;
 	}
 
 	async internalGet( params, userAgent ) {

--- a/test/integration/browser.test.js
+++ b/test/integration/browser.test.js
@@ -8,7 +8,7 @@ describe( 'BrowserSession', function () {
 	this.timeout( 60000 );
 
 	it( 'siteinfo, array siprops, default formatversion+origin', async () => {
-		const session = new BrowserSession( 'https://en.wikipedia.org/w/api.php', {
+		const session = new BrowserSession( 'en.wikipedia.org', {
 			formatversion: 2,
 			origin: '*',
 		}, {
@@ -26,7 +26,7 @@ describe( 'BrowserSession', function () {
 	} );
 
 	it( 'validatepassword', async function () {
-		const session = new BrowserSession( 'https://en.wikipedia.org/w/api.php', {
+		const session = new BrowserSession( 'en.wikipedia.org', {
 			formatversion: 2,
 			origin: '*',
 		}, {

--- a/test/integration/node.test.js
+++ b/test/integration/node.test.js
@@ -9,7 +9,7 @@ describe( 'NodeSession', function () {
 	this.timeout( 60000 );
 
 	it( 'siteinfo, array siprops, default formatversion', async () => {
-		const session = new NodeSession( 'https://en.wikipedia.org/w/api.php', {
+		const session = new NodeSession( 'en.wikipedia.org', {
 			formatversion: 2,
 		}, {
 			userAgent: 'm3api-integration-tests',
@@ -26,7 +26,7 @@ describe( 'NodeSession', function () {
 	} );
 
 	it( 'validatepassword', async function () {
-		const session = new NodeSession( 'https://en.wikipedia.org/w/api.php', {
+		const session = new NodeSession( 'en.wikipedia.org', {
 			formatversion: 2,
 		}, {
 			userAgent: 'm3api-integration-tests',
@@ -42,7 +42,7 @@ describe( 'NodeSession', function () {
 		if ( !( 'MEDIAWIKI_USERNAME' in process.env && 'MEDIAWIKI_PASSWORD' in process.env ) ) {
 			return this.skip();
 		}
-		const session = new NodeSession( 'https://en.wikipedia.beta.wmflabs.org/w/api.php', {
+		const session = new NodeSession( 'en.wikipedia.beta.wmflabs.org', {
 			formatversion: 2,
 		}, {
 			userAgent: 'm3api-integration-tests',

--- a/test/unit/combine.test.js
+++ b/test/unit/combine.test.js
@@ -40,7 +40,7 @@ describe( 'CombiningSession', () => {
 		}
 		mixCombiningSessionInto( TestSession );
 
-		return new TestSession( 'https://en.wikipedia.org/w/api.php' );
+		return new TestSession( 'en.wikipedia.org' );
 	}
 
 	describe( 'combines compatible requests', () => {
@@ -270,7 +270,7 @@ describe( 'CombiningSession', () => {
 		}
 		mixCombiningSessionInto( TestSession );
 
-		const session = new TestSession( 'https://en.wikipedia.org/w/api.php' );
+		const session = new TestSession( 'en.wikipedia.org' );
 		await expect( session.request() )
 			.to.be.rejectedWith( error );
 	} );
@@ -345,7 +345,7 @@ describe( 'CombiningSession', () => {
 		}
 		mixCombiningSessionInto( TestSession );
 
-		return new TestSession( 'https://en.wikipedia.org/w/api.php' );
+		return new TestSession( 'en.wikipedia.org' );
 	}
 
 	describe( 'supports sequential requests', () => {

--- a/test/unit/core.test.js
+++ b/test/unit/core.test.js
@@ -54,7 +54,7 @@ describe( 'ApiErrors', () => {
 
 describe( 'Session', () => {
 
-	const session = new BaseTestSession( 'https://en.wikipedia.org/w/api.php' );
+	const session = new BaseTestSession( 'en.wikipedia.org' );
 
 	describe( 'apiUrl', () => {
 
@@ -135,7 +135,7 @@ describe( 'Session', () => {
 				}
 			}
 
-			const session = new TestSession( 'https://en.wikipedia.org/w/api.php' );
+			const session = new TestSession( 'en.wikipedia.org' );
 			await expect( session.request( { action: 'query' } ) )
 				.to.be.rejectedWith( '502' );
 		} );
@@ -157,7 +157,7 @@ describe( 'Session', () => {
 					}
 				}
 
-				const session = new TestSession( 'https://en.wikipedia.org/w/api.php', {}, {
+				const session = new TestSession( 'en.wikipedia.org', {}, {
 					userAgent: 'user-agent',
 				} );
 				await session.request( {} );
@@ -179,7 +179,7 @@ describe( 'Session', () => {
 					}
 				}
 
-				const session = new TestSession( 'https://en.wikipedia.org/w/api.php' );
+				const session = new TestSession( 'en.wikipedia.org' );
 				await session.request( {}, {
 					userAgent: 'user-agent',
 				} );
@@ -203,7 +203,7 @@ describe( 'Session', () => {
 						}
 					}
 
-					const session = new TestSession( 'https://en.wikipedia.org/w/api.php' );
+					const session = new TestSession( 'en.wikipedia.org' );
 					await session.request( {}, { userAgent: undefined, warn: () => {} } );
 					expect( called ).to.be.true;
 				} );
@@ -226,7 +226,7 @@ describe( 'Session', () => {
 						}
 					}
 
-					const session = new TestSession( 'https://en.wikipedia.org/w/api.php' );
+					const session = new TestSession( 'en.wikipedia.org' );
 					await session.request( {}, { userAgent: undefined, warn } );
 					expect( warnCalled ).to.be.true;
 					await session.request( {}, { userAgent: undefined, warn } );
@@ -250,11 +250,11 @@ describe( 'Session', () => {
 						}
 					}
 
-					await new TestSession( 'https://en.wikipedia.org/w/api.php' )
+					await new TestSession( 'en.wikipedia.org' )
 						.request( {}, { userAgent: undefined, warn } );
 					expect( warnCalled ).to.be.true;
 					warnCalled = false;
-					await new TestSession( 'https://en.wikipedia.org/w/api.php' )
+					await new TestSession( 'en.wikipedia.org' )
 						.request( {}, { userAgent: undefined, warn } );
 					expect( warnCalled ).to.be.true;
 					warnCalled = false;
@@ -299,7 +299,7 @@ describe( 'Session', () => {
 					}
 				}
 
-				const session = new TestSession( 'https://en.wikipedia.org/w/api.php' );
+				const session = new TestSession( 'en.wikipedia.org' );
 				const promise = session.request( {} );
 				clock.tickAsync( 5000 );
 				const response = await promise;
@@ -331,7 +331,7 @@ describe( 'Session', () => {
 					}
 				}
 
-				const session = new TestSession( 'https://en.wikipedia.org/w/api.php' );
+				const session = new TestSession( 'en.wikipedia.org' );
 				const promise = session.request( {}, { maxRetries: 5 } );
 				for ( let i = 0; i < 3; i++ ) {
 					clock.tickAsync( 5000 );
@@ -359,7 +359,7 @@ describe( 'Session', () => {
 					}
 				}
 
-				const session = new TestSession( 'https://en.wikipedia.org/w/api.php', {}, {
+				const session = new TestSession( 'en.wikipedia.org', {}, {
 					maxRetries: 0,
 				} );
 				const response = await session.request( {} );
@@ -440,7 +440,7 @@ describe( 'Session', () => {
 				}
 			}
 
-			const session = new TestSession( 'https://en.wikipedia.org/w/api.php', {
+			const session = new TestSession( 'en.wikipedia.org', {
 				formatversion: 2,
 			} );
 			const params = {
@@ -520,7 +520,7 @@ describe( 'Session', () => {
 				}
 			}
 
-			const session = new TestSession( 'https://en.wikipedia.org/w/api.php', {
+			const session = new TestSession( 'en.wikipedia.org', {
 				formatversion: 2,
 			} );
 			const params = {

--- a/test/unit/core.test.js
+++ b/test/unit/core.test.js
@@ -56,6 +56,20 @@ describe( 'Session', () => {
 
 	const session = new BaseTestSession( 'https://en.wikipedia.org/w/api.php' );
 
+	describe( 'apiUrl', () => {
+
+		it( 'full URL', () => {
+			const session = new BaseTestSession( 'https://starwars.fandom.com/api.php' );
+			expect( session.apiUrl ).to.equal( 'https://starwars.fandom.com/api.php' );
+		} );
+
+		it( 'domain', () => {
+			const session = new BaseTestSession( 'en.wikipedia.org' );
+			expect( session.apiUrl ).to.equal( 'https://en.wikipedia.org/w/api.php' );
+		} );
+
+	} );
+
 	describe( 'transformParamValue', () => {
 		for ( const [ value, expected ] of [
 			[ 'a string', 'a string' ],


### PR DESCRIPTION
If the first constructor argument doesn’t contain a slash, surround it in https://…/w/api.php. This makes it much more convenient to create sessions for Wikimedia wikis, and many other installations as well (as long as they use HTTPS and have /w as the script path).

Fixes #7.